### PR TITLE
Developer

### DIFF
--- a/app/modules/adminModule/groupEventHandlers.js
+++ b/app/modules/adminModule/groupEventHandlers.js
@@ -136,17 +136,13 @@ const handleGroupUpdate = async (sock, groupId, participants, action) => {
           }
           break;
         case 'promote':
-          if (groupConfig.promoteMessageEnabled && groupConfig.promoteMessage) {
-            let msg = groupConfig.promoteMessage.replace('{participant}', `@${participantName}`);
-            msg = msg.replace(/@user/g, `@${participantName}`);
-            message += `${msg}\n`;
+          if (groupConfig.welcomeMessageEnabled) {
+            message += `O usuário @${participantName} foi promovido a administrador do grupo. 🎉\n`;
           }
           break;
         case 'demote':
-          if (groupConfig.demoteMessageEnabled && groupConfig.demoteMessage) {
-            let msg = groupConfig.demoteMessage.replace('{participant}', `@${participantName}`);
-            msg = msg.replace(/@user/g, `@${participantName}`);
-            message += `${msg}\n`;
+          if (groupConfig.welcomeMessageEnabled) {
+            message += `O usuário @${participantName} não é mais um administrador do grupo. ⬇️\n`;
           }
           break;
       }

--- a/app/modules/adminModule/groupEventHandlers.js
+++ b/app/modules/adminModule/groupEventHandlers.js
@@ -1,200 +1,239 @@
-// app/modules/adminModule/groupEventHandlers.js
-
 const groupConfigStore = require('../../store/groupConfigStore');
 const store = require('../../store/dataStore');
 const logger = require('../../utils/logger/loggerModule');
-const groupUtils = require('../../utils/groupUtils'); // Import groupUtils
+const groupUtils = require('../../utils/groupUtils');
 const fs = require('fs');
 const path = require('path');
 const moment = require('moment-timezone');
 
-/**
- * Handles group update events (add, remove, promote, demote) and sends
- * welcome/farewell/promotion/demotion messages based on group configurations.
- * @param {import('@adiwajshing/baileys').WASocket} sock - The Baileys socket instance.
- * @param {string} groupId - The JID of the group where the event occurred.
- * @param {string[]} participants - The JIDs of the participants involved in the event.
- * @param {'add' | 'remove' | 'promote' | 'demote'} action - The action that occurred.
- */
-
-/**
- * Replaces placeholders in a message string with actual group information.
- * @param {string} message - The message string potentially containing placeholders.
- * @param {import('@adiwajshing/baileys').WASocket} sock - The Baileys socket instance.
- * @param {string} groupId - The JID of the group.
- * @returns {Promise<{updatedMessage: string, mentions: string[]}>} The message string with placeholders replaced and an array of JIDs to mention.
- */
 const replacePlaceholders = async (message, sock, groupId) => {
-    let updatedMessage = message;
-    const mentions = [];
+  logger.debug('Iniciando substituição de placeholders para a mensagem.', { groupId });
+  let updatedMessage = message;
+  const mentions = [];
 
-    try {
-        const metadata = await groupUtils.getGroupMetadata(sock, groupId);
+  try {
+    const metadata = await groupUtils.getGroupMetadata(sock, groupId);
+    logger.debug('Metadados do grupo obtidos para substituição de placeholders.', {
+      groupId,
+      subject: metadata.subject,
+    });
 
-        // @date: Current date and time
-        if (updatedMessage.includes('@date')) {
-            updatedMessage = updatedMessage.replace(/@date/g, moment().format('DD/MM/YYYY HH:mm:ss'));
-        }
-
-        // @desc: Group description
-        if (updatedMessage.includes('@desc') && metadata.desc) {
-            updatedMessage = updatedMessage.replace(/@desc/g, metadata.desc);
-        }
-
-        // @admins: List of admin names and add them to mentions
-        if (updatedMessage.includes('@admins') && metadata.participants) {
-            const adminJids = metadata.participants
-                .filter(p => p.admin === 'admin' || p.admin === 'superadmin')
-                .map(p => p.id);
-            
-            const adminNames = adminJids.map(jid => {
-                const contact = store.contacts && store.contacts[jid];
-                mentions.push(jid);
-                return `@${jid.split('@')[0]}`;
-            });
-            updatedMessage = updatedMessage.replace(/@admins/g, adminNames.join(', '));
-        }
-
-        // @groupname: Group subject
-        if (updatedMessage.includes('@groupname') && metadata.subject) {
-            updatedMessage = updatedMessage.replace(/@groupname/g, metadata.subject);
-        }
-
-        // @membercount: Current member count
-        if (updatedMessage.includes('@membercount') && metadata.participants) {
-            updatedMessage = updatedMessage.replace(/@membercount/g, metadata.participants.length.toString());
-        }
-
-        // @owner: Group owner's name or JID
-        if (updatedMessage.includes('@owner') && metadata.owner) {
-            const ownerJid = metadata.owner;
-            const ownerName = (store.contacts && store.contacts[ownerJid]?.notify) || ownerJid.split('@')[0];
-            mentions.push(ownerJid);
-            updatedMessage = updatedMessage.replace(/@owner/g, `@${ownerName}`);
-        }
-
-        // @creationtime: Group creation timestamp
-        if (updatedMessage.includes('@creationtime') && metadata.creation) {
-            updatedMessage = updatedMessage.replace(/@creationtime/g, moment.unix(metadata.creation).format('DD/MM/YYYY HH:mm:ss'));
-        }
-
-        // @invitecode: Group invite code
-        if (updatedMessage.includes('@invitecode')) {
-            try {
-                const inviteCode = await groupUtils.getGroupInviteCode(sock, groupId);
-                updatedMessage = updatedMessage.replace(/@invitecode/g, inviteCode);
-            } catch (e) {
-                logger.warn(`Could not get invite code for group ${groupId}: ${e.message}`);
-                updatedMessage = updatedMessage.replace(/@invitecode/g, '[Código de convite não disponível]');
-            }
-        }
-
-        // @isrestricted: Is group restricted?
-        if (updatedMessage.includes('@isrestricted')) {
-            updatedMessage = updatedMessage.replace(/@isrestricted/g, metadata.restrict ? 'Sim' : 'Não');
-        }
-
-        // @isannounceonly: Is group announcement only?
-        if (updatedMessage.includes('@isannounceonly')) {
-            updatedMessage = updatedMessage.replace(/@isannounceonly/g, metadata.announce ? 'Sim' : 'Não');
-        }
-
-    } catch (error) {
-        logger.error(`Error replacing placeholders for group ${groupId}: ${error.message}`);
+    if (updatedMessage.includes('@date')) {
+      updatedMessage = updatedMessage.replace(/@date/g, moment().format('DD/MM/YYYY HH:mm:ss'));
     }
-    return { updatedMessage, mentions };
+
+    if (updatedMessage.includes('@desc') && metadata.desc) {
+      updatedMessage = updatedMessage.replace(/@desc/g, metadata.desc);
+    }
+
+    if (updatedMessage.includes('@admins') && metadata.participants) {
+      const adminJids = metadata.participants
+        .filter((p) => p.admin === 'admin' || p.admin === 'superadmin')
+        .map((p) => p.id);
+
+      const adminNames = adminJids.map((jid) => {
+        const contact = store.contacts && store.contacts[jid];
+        mentions.push(jid);
+        return `@${jid.split('@')[0]}`;
+      });
+      updatedMessage = updatedMessage.replace(/@admins/g, adminNames.join(', '));
+    }
+
+    if (updatedMessage.includes('@groupname') && metadata.subject) {
+      updatedMessage = updatedMessage.replace(/@groupname/g, metadata.subject);
+    }
+
+    if (updatedMessage.includes('@membercount') && metadata.participants) {
+      updatedMessage = updatedMessage.replace(
+        /@membercount/g,
+        metadata.participants.length.toString(),
+      );
+    }
+
+    if (updatedMessage.includes('@owner') && metadata.owner) {
+      const ownerJid = metadata.owner;
+      const ownerName =
+        (store.contacts && store.contacts[ownerJid]?.notify) || ownerJid.split('@')[0];
+      mentions.push(ownerJid);
+      updatedMessage = updatedMessage.replace(/@owner/g, `@${ownerName}`);
+    }
+
+    if (updatedMessage.includes('@creationtime') && metadata.creation) {
+      updatedMessage = updatedMessage.replace(
+        /@creationtime/g,
+        moment.unix(metadata.creation).format('DD/MM/YYYY HH:mm:ss'),
+      );
+    }
+
+    if (updatedMessage.includes('@invitecode')) {
+      try {
+        const inviteCode = await groupUtils.getGroupInviteCode(sock, groupId);
+        updatedMessage = updatedMessage.replace(/@invitecode/g, inviteCode);
+      } catch (e) {
+        logger.warn(
+          `Não foi possível obter o código de convite para o grupo ${groupId}. O placeholder não será substituído.`,
+          { error: e.message },
+        );
+        updatedMessage = updatedMessage.replace(
+          /@invitecode/g,
+          '[Código de convite não disponível]',
+        );
+      }
+    }
+
+    if (updatedMessage.includes('@isrestricted')) {
+      updatedMessage = updatedMessage.replace(/@isrestricted/g, metadata.restrict ? 'Sim' : 'Não');
+    }
+
+    if (updatedMessage.includes('@isannounceonly')) {
+      updatedMessage = updatedMessage.replace(
+        /@isannounceonly/g,
+        metadata.announce ? 'Sim' : 'Não',
+      );
+    }
+  } catch (error) {
+    logger.error(`Erro ao substituir placeholders para o grupo ${groupId}.`, {
+      errorMessage: error.message,
+      stack: error.stack,
+    });
+  }
+  logger.debug('Substituição de placeholders finalizada.', { groupId });
+  return { updatedMessage, mentions };
 };
 
 const handleGroupUpdate = async (sock, groupId, participants, action) => {
+  logger.debug('Iniciando tratamento de evento de atualização de grupo.', {
+    groupId,
+    participants,
+    action,
+  });
 
-    try {
-        const groupConfig = groupConfigStore.getGroupConfig(groupId);
-        let message = '';
-        const allMentions = [];
+  try {
+    const groupConfig = groupConfigStore.getGroupConfig(groupId);
+    logger.debug('Configurações do grupo carregadas.', { groupId, config: groupConfig });
 
-        for (const participantJid of participants) {
-            const participantName = (store.contacts && store.contacts[participantJid]?.notify) || participantJid.split('@')[0];
-            allMentions.push(participantJid);
+    let message = '';
+    const allMentions = [];
 
-            switch (action) {
-                case 'add':
-                    if (groupConfig.welcomeMessageEnabled && groupConfig.welcomeMessage) {
-                        let msg = groupConfig.welcomeMessage.replace('{participant}', `@${participantName}`);
-                        msg = msg.replace(/@user/g, `@${participantName}`); // Add this line for @user
-                        message += `${msg}\n`;
-                    }
-                    break;
-                case 'remove':
-                    if (groupConfig.farewellMessageEnabled && groupConfig.farewellMessage) {
-                        let msg = groupConfig.farewellMessage.replace('{participant}', `@${participantName}`);
-                        msg = msg.replace(/@user/g, `@${participantName}`); // Add this line for @user
-                        message += `${msg}\n`;
-                    }
-                    break;
-                case 'promote':
-                    if (groupConfig.promoteMessageEnabled && groupConfig.promoteMessage) {
-                        let msg = groupConfig.promoteMessage.replace('{participant}', `@${participantName}`);
-                        msg = msg.replace(/@user/g, `@${participantName}`); // Add this line for @user
-                        message += `${msg}\n`;
-                    }
-                    break;
-                case 'demote':
-                    if (groupConfig.demoteMessageEnabled && groupConfig.demoteMessage) {
-                        let msg = groupConfig.demoteMessage.replace('{participant}', `@${participantName}`);
-                        msg = msg.replace(/@user/g, `@${participantName}`); // Add this line for @user
-                        message += `${msg}\n`;
-                    }
-                    break;
-            }
-        }
+    for (const participantJid of participants) {
+      const participantName =
+        (store.contacts && store.contacts[participantJid]?.notify) || participantJid.split('@')[0];
+      allMentions.push(participantJid);
 
-        if (message) {
-            let messageOptions = {};
-            let mediaPath = null;
-
-            // Replace group-level placeholders in the message and get additional mentions
-            const { updatedMessage, mentions: groupMentions } = await replacePlaceholders(message, sock, groupId);
-            message = updatedMessage;
-
-            // Combine all mentions
-            const finalMentions = [...new Set([...allMentions, ...groupMentions])];
-
-            if (action === 'add' && groupConfig.welcomeMedia) {
-                mediaPath = groupConfig.welcomeMedia;
-            } else if (action === 'remove' && groupConfig.farewellMedia) {
-                mediaPath = groupConfig.farewellMedia;
-            }
-
-            if (mediaPath) {
-                logger.info(`Attempting to send media. Configured mediaPath: ${mediaPath}`);
-                const absoluteMediaPath = path.resolve(mediaPath);
-                logger.info(`Resolved absoluteMediaPath: ${absoluteMediaPath}`);
-
-                if (fs.existsSync(absoluteMediaPath)) {
-                    logger.info(`Media file found at ${absoluteMediaPath}. Preparing to send.`);
-                    const mediaType = absoluteMediaPath.endsWith('.mp4') ? 'video' : 'image';
-                    const mediaBuffer = fs.readFileSync(absoluteMediaPath);
-
-                    if (mediaType === 'image') {
-                        messageOptions = { image: mediaBuffer, caption: message.trim(), mentions: finalMentions };
-                    } else if (mediaType === 'video') {
-                        messageOptions = { video: mediaBuffer, caption: message.trim(), mentions: finalMentions };
-                    }
-                } else {
-                    logger.warn(`Media file not found at ${absoluteMediaPath} for group ${groupId}, action ${action}. Sending text message instead.`);
-                    messageOptions = { text: message.trim(), mentions: finalMentions };
-                }
-            } else {
-                messageOptions = { text: message.trim(), mentions: finalMentions };
-            }
-            await sock.sendMessage(groupId, messageOptions);
-            logger.info(`Sent group update message for group ${groupId}, action: ${action}`);
-        }
-    } catch (error) {
-        logger.error(`Error handling group update for group ${groupId}, action ${action}:`, error);
+      switch (action) {
+        case 'add':
+          if (groupConfig.welcomeMessageEnabled && groupConfig.welcomeMessage) {
+            let msg = groupConfig.welcomeMessage.replace('{participant}', `@${participantName}`);
+            msg = msg.replace(/@user/g, `@${participantName}`);
+            message += `${msg}\n`;
+          }
+          break;
+        case 'remove':
+          if (groupConfig.farewellMessageEnabled && groupConfig.farewellMessage) {
+            let msg = groupConfig.farewellMessage.replace('{participant}', `@${participantName}`);
+            msg = msg.replace(/@user/g, `@${participantName}`);
+            message += `${msg}\n`;
+          }
+          break;
+        case 'promote':
+          if (groupConfig.promoteMessageEnabled && groupConfig.promoteMessage) {
+            let msg = groupConfig.promoteMessage.replace('{participant}', `@${participantName}`);
+            msg = msg.replace(/@user/g, `@${participantName}`);
+            message += `${msg}\n`;
+          }
+          break;
+        case 'demote':
+          if (groupConfig.demoteMessageEnabled && groupConfig.demoteMessage) {
+            let msg = groupConfig.demoteMessage.replace('{participant}', `@${participantName}`);
+            msg = msg.replace(/@user/g, `@${participantName}`);
+            message += `${msg}\n`;
+          }
+          break;
+      }
     }
+
+    if (message) {
+      logger.debug('Mensagem de evento de grupo gerada.', { groupId, action, message });
+      let messageOptions = {};
+      let mediaPath = null;
+
+      const { updatedMessage, mentions: groupMentions } = await replacePlaceholders(
+        message,
+        sock,
+        groupId,
+      );
+      message = updatedMessage;
+
+      const finalMentions = [...new Set([...allMentions, ...groupMentions])];
+      logger.debug('Menções para a mensagem final processadas.', {
+        groupId,
+        finalMentionsCount: finalMentions.length,
+      });
+
+      if (action === 'add' && groupConfig.welcomeMedia) {
+        mediaPath = groupConfig.welcomeMedia;
+      } else if (action === 'remove' && groupConfig.farewellMedia) {
+        mediaPath = groupConfig.farewellMedia;
+      }
+
+      if (mediaPath) {
+        logger.info(`Tentando enviar mensagem com mídia para o grupo ${groupId}.`, {
+          action,
+          mediaPath,
+        });
+        const absoluteMediaPath = path.resolve(mediaPath);
+        logger.debug(`Caminho absoluto da mídia resolvido: ${absoluteMediaPath}`);
+
+        if (fs.existsSync(absoluteMediaPath)) {
+          logger.info(
+            `Arquivo de mídia encontrado em ${absoluteMediaPath}. Preparando para enviar.`,
+          );
+          const mediaType = absoluteMediaPath.endsWith('.mp4') ? 'video' : 'image';
+          const mediaBuffer = fs.readFileSync(absoluteMediaPath);
+
+          if (mediaType === 'image') {
+            messageOptions = {
+              image: mediaBuffer,
+              caption: message.trim(),
+              mentions: finalMentions,
+            };
+          } else if (mediaType === 'video') {
+            messageOptions = {
+              video: mediaBuffer,
+              caption: message.trim(),
+              mentions: finalMentions,
+            };
+          }
+        } else {
+          logger.warn(
+            `Arquivo de mídia não encontrado em ${absoluteMediaPath} para o grupo ${groupId}. Ação: ${action}. Enviando apenas a mensagem de texto.`,
+          );
+          messageOptions = { text: message.trim(), mentions: finalMentions };
+        }
+      } else {
+        logger.debug('Nenhuma mídia configurada para este evento. Enviando apenas texto.', {
+          groupId,
+          action,
+        });
+        messageOptions = { text: message.trim(), mentions: finalMentions };
+      }
+      await sock.sendMessage(groupId, messageOptions);
+      logger.info(`Mensagem de atualização de grupo enviada com sucesso para o grupo ${groupId}.`, {
+        action,
+        participants,
+      });
+    } else {
+      logger.debug('Nenhuma mensagem de evento de grupo para enviar.', { groupId, action });
+    }
+  } catch (error) {
+    logger.error(`Erro ao tratar atualização de grupo para o grupo ${groupId}, ação ${action}:`, {
+      errorMessage: error.message,
+      stack: error.stack,
+      error,
+    });
+  }
 };
 
 module.exports = {
-    handleGroupUpdate,
+  handleGroupUpdate,
 };

--- a/app/modules/adminModule/groupEventHandlers.js
+++ b/app/modules/adminModule/groupEventHandlers.js
@@ -122,15 +122,18 @@ const handleGroupUpdate = async (sock, groupId, participants, action) => {
 
       switch (action) {
         case 'add':
-          if (groupConfig.welcomeMessageEnabled && groupConfig.welcomeMessage) {
-            let msg = groupConfig.welcomeMessage.replace('{participant}', `@${participantName}`);
+          if (groupConfig.welcomeMessageEnabled) {
+            const welcomeMsg =
+              groupConfig.welcomeMessage || '👋 Bem-vindo(a) ao grupo @groupname, @user! 🎉';
+            let msg = welcomeMsg.replace('{participant}', `@${participantName}`);
             msg = msg.replace(/@user/g, `@${participantName}`);
             message += `${msg}\n`;
           }
           break;
         case 'remove':
-          if (groupConfig.farewellMessageEnabled && groupConfig.farewellMessage) {
-            let msg = groupConfig.farewellMessage.replace('{participant}', `@${participantName}`);
+          if (groupConfig.farewellMessageEnabled) {
+            const farewellMsg = groupConfig.farewellMessage || '😥 Adeus, @user! Sentiremos sua falta.';
+            let msg = farewellMsg.replace('{participant}', `@${participantName}`);
             msg = msg.replace(/@user/g, `@${participantName}`);
             message += `${msg}\n`;
           }

--- a/app/modules/adminModule/infoCommand.js
+++ b/app/modules/adminModule/infoCommand.js
@@ -10,27 +10,22 @@ const handleInfoCommand = async (
   remoteJid,
   expirationMessage,
 ) => {
-  let targetGroupId;
-  let messageLimit = NaN; // Initialize messageLimit
-
   const inactiveIndex = args.indexOf('--inativos');
 
   if (inactiveIndex !== -1) {
-    // --inativos is present
-    // Try to get targetGroupId from argument before --inativos
+    let targetGroupId;
+    let messageLimit = NaN;
+
     if (inactiveIndex > 0 && args[inactiveIndex - 1].includes('@g.us')) {
       targetGroupId = args[inactiveIndex - 1];
     } else if (isGroupMessage) {
-      // If in a group chat, use current group ID
       targetGroupId = remoteJid;
     }
 
-    // Get messageLimit from argument after --inativos
     if (args.length > inactiveIndex + 1) {
       messageLimit = parseInt(args[inactiveIndex + 1]);
     }
 
-    // If targetGroupId is still not set and it's a private chat, prompt for it
     if (!targetGroupId) {
       logger.warn('ID do grupo não fornecido para /info --inativos em chat privado.');
       await sock.sendMessage(
@@ -42,12 +37,94 @@ const handleInfoCommand = async (
       );
       return;
     }
-  } else {
-    // --inativos is NOT present (original /info command behavior)
-    targetGroupId = args[0] || (isGroupMessage ? remoteJid : null);
+    if (isNaN(messageLimit)) {
+      logger.warn('Limite de mensagens inválido para /info --inativos.');
+      await sock.sendMessage(
+        remoteJid,
+        {
+          text: '⚠️ *Uso incorreto do comando --inativos. Por favor, forneça um número válido como limite.*\n\nExemplo: `/info --inativos 10`',
+        },
+        { quoted: messageInfo, ephemeralExpiration: expirationMessage },
+      );
+      return;
+    }
+
+    const groupInfo = groupUtils.getGroupInfo(targetGroupId);
+    if (!groupInfo) {
+      logger.info(`Grupo com ID ${targetGroupId} não encontrado.`);
+      await sock.sendMessage(
+        remoteJid,
+        { text: `❌ *Grupo com ID ${targetGroupId} não encontrado.*` },
+        { quoted: messageInfo, ephemeralExpiration: expirationMessage },
+      );
+      return;
+    }
+
+    const allParticipants = groupUtils.getGroupParticipants(targetGroupId) || [];
+    const messages = store.rawMessages[targetGroupId] || [];
+    const mentions = [];
+
+    if (messages.length === 0) {
+      await sock.sendMessage(
+        remoteJid,
+        { text: '📊 *Nenhuma mensagem encontrada no histórico para este grupo.*' },
+        { quoted: messageInfo, ephemeralExpiration: expirationMessage },
+      );
+      return;
+    }
+
+    const participantCounts = {};
+    let firstMessageTimestamp = Infinity;
+
+    messages.forEach((msg) => {
+      const participant = msg.key.fromMe
+        ? sock.user.id.split(':')[0] + '@s.whatsapp.net'
+        : msg.key.participant || msg.participant;
+      if (participant) {
+        participantCounts[participant] = (participantCounts[participant] || 0) + 1;
+      }
+      const timestamp = msg.messageTimestamp;
+      if (timestamp < firstMessageTimestamp) {
+        firstMessageTimestamp = timestamp;
+      }
+    });
+
+    const inactiveUsers = allParticipants
+      .map((p) => ({
+        jid: p.id,
+        count: participantCounts[p.id] || 0,
+      }))
+      .filter((user) => user.count < messageLimit)
+      .sort((a, b) => a.count - b.count);
+
+    let reply = `Análise de Inatividade para o grupo: *${groupInfo.subject}*\n\n`;
+    reply += `*Total de mensagens registradas:* ${messages.length}\n`;
+    reply += `*Análise de mensagens desde:* ${new Date(
+      firstMessageTimestamp * 1000,
+    ).toLocaleString()}\n\n`;
+
+    if (inactiveUsers.length > 0) {
+      reply += `😴 *Usuários Inativos (menos de ${messageLimit} mensagens):* 📉\n`;
+      inactiveUsers.forEach(({ jid, count }) => {
+        mentions.push(jid);
+        const name = `@${jid.split('@')[0]}`;
+        reply += `- ${name} (${count} mensagens)\n`;
+      });
+    } else {
+      reply += `🎉 *Nenhum usuário inativo encontrado com menos de ${messageLimit} mensagens.*`;
+    }
+
+    await sock.sendMessage(
+      remoteJid,
+      { text: reply, mentions: mentions },
+      { quoted: messageInfo, ephemeralExpiration: expirationMessage },
+    );
+    return; // End execution here
   }
 
-  // Final check for targetGroupId if it wasn't handled by --inativos logic
+  // --- FULL INFO LOGIC (if --inativos is not present) ---
+  let targetGroupId = args[0] || (isGroupMessage ? remoteJid : null);
+
   if (!targetGroupId) {
     logger.warn('ID do grupo não fornecido para /info em chat privado.');
     await sock.sendMessage(
@@ -93,6 +170,8 @@ const handleInfoCommand = async (
       .join(', ');
   }
 
+  const allParticipants = groupUtils.getGroupParticipants(targetGroupId) || [];
+
   let reply =
     `📋 *Informações do Grupo:* ℹ️\n\n` +
     `🆔 *ID:* 🔢 ${groupInfo.id.split('@')[0]}\n` +
@@ -109,9 +188,7 @@ const handleInfoCommand = async (
     `🏘️ *Comunidade:* 🏡 ${groupUtils.isGroupCommunity(targetGroupId) ? 'Sim' : 'Não'}\n` +
     `🗣️ *Descrição:* ✍️ ${groupUtils.getGroupDescription(targetGroupId) || 'N/A'}\n` +
     `🛡️ *Administradores:* 👮‍♂️ ${adminsText}\n` +
-    `👤 *Total de Participantes:* 🧑‍🤝‍🧑 ${
-      groupUtils.getGroupParticipants(targetGroupId)?.length || 'Nenhum'
-    }`;
+    `👤 *Total de Participantes:* 🧑‍🤝‍🧑 ${allParticipants.length || 'Nenhum'}`;
 
   const messages = store.rawMessages[targetGroupId] || [];
   let messageRanking = '';
@@ -256,32 +333,6 @@ const handleInfoCommand = async (
     temporalActivity += '\n\n⏳ *Atividade Temporal* 📈\n';
     temporalActivity += calculateTemporalActivity(messagesLast12Hours, 'Últimas 12 Horas 🕛');
     temporalActivity += calculateTemporalActivity(messagesLast7Days, 'Últimos 7 Dias 🗓️');
-
-    const inactiveIndex = args.indexOf('--inativos');
-    if (inactiveIndex !== -1 && args.length > inactiveIndex + 1) {
-      const messageLimit = parseInt(args[inactiveIndex + 1]);
-      if (!isNaN(messageLimit)) {
-        const inactiveUsers = Object.entries(participantCounts).filter(
-          ([jid, count]) => count < messageLimit
-        );
-
-        if (inactiveUsers.length > 0) {
-          let inactiveUsersText = `\n\n😴 *Usuários Inativos (menos de ${messageLimit} mensagens):* 📉\n`;
-          inactiveUsers.forEach(([jid, count]) => {
-            if (!mentions.includes(jid)) {
-              mentions.push(jid);
-            }
-            const name = `@${jid.split('@')[0]}`;
-            inactiveUsersText += `- ${name} (${count} mensagens)\n`;
-          });
-          reply += inactiveUsersText;
-        } else {
-          reply += `\n\n🎉 *Nenhum usuário inativo encontrado com menos de ${messageLimit} mensagens.*`;
-        }
-      } else {
-        reply += `\n\n⚠️ *Uso incorreto do comando --inativos. Por favor, forneça um número válido.*`;
-      }
-    }
   } else {
     messageRanking = '\n\n📊 *Ranking de Mensagens:* Nenhuma mensagem encontrada no histórico. 😔';
   }

--- a/app/utils/logger/loggerModule.js
+++ b/app/utils/logger/loggerModule.js
@@ -238,10 +238,13 @@ const createLoggerInstance = (overrideOptions = {}) => {
 
   const defaultMeta = { ...baseDefaultMeta, ...(overrideOptions.defaultMeta || {}) };
 
+  const loggerFormat =
+    overrideOptions.format || winston.format.combine(winston.format.errors({ stack: true }));
+
   const loggerInstance = winston.createLogger({
     level: effectiveLevel,
     levels: LOG_LEVELS,
-    format: winston.format.combine(winston.format.errors({ stack: true })),
+    format: loggerFormat,
     defaultMeta: defaultMeta,
     transports: configuredTransports,
     exitOnError: false,


### PR DESCRIPTION
Enhances the `/info` command to include an analysis of inactive users within a group.

This update introduces the `--inativos` flag, allowing admins to identify users who have sent fewer than a specified number of messages. It provides a clearer and more informative output, including total messages, the analysis period, and a list of inactive users with their message counts.

The original logic for the full group info display is preserved and activated when `--inativos` is not used.